### PR TITLE
Expose backlog to Argyle consumers.

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,14 +5,18 @@ var net = require('net')
 
 var debugOut = console.log.bind(console)
 
-module.exports = function(port, host, debug) {
+module.exports = function(port, host, backlog, debug) {
   if(!port) port = 8080
   if(!host) host = '127.0.0.1'
+  if(typeof backlog === 'boolean') {
+    debug = backlog
+    backlog = undefined
+  }
 
-  return new Argyle(port, host, debug)
+  return new Argyle(port, host, backlog, debug)
 }
 
-function Argyle(port, host, debug) {
+function Argyle(port, host, backlog, debug) {
   Argyle.super_.call(this)
   var self = this
 
@@ -27,7 +31,11 @@ function Argyle(port, host, debug) {
     self.handleConnection(client)
   })
 
-  this.serverSock.listen(port, host)
+  if(backlog) {
+    this.serverSock.listen(port, host, backlog)
+  } else {
+    this.serverSock.listen(port, host)
+  }
 }
 util.inherits(Argyle, EventEmitter);
 

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "author": "Travis Collins <travis@tec27.com> (http://tec27.com)",
   "name": "argyle",
   "description": "Basic SOCKS5 server libary",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "repository": {
     "type": "git",
     "url": "git://github.com/tec27/node-argyle.git"


### PR DESCRIPTION
This change allows users to specify the maximium length of the queue of pending
connections and does so in a way that does not break API compatibility.

Node API details here:
https://nodejs.org/api/net.html#net_server_listen_port_hostname_backlog_callback